### PR TITLE
Fix unit test dependency on timezone

### DIFF
--- a/Polygon.Client.UnitTests/GetDailyMarketSummaryUnitTests.cs
+++ b/Polygon.Client.UnitTests/GetDailyMarketSummaryUnitTests.cs
@@ -51,7 +51,7 @@ namespace Polygon.Client.UnitTests
         public async Task GetDailyMarketSummary_With_Future_Date_Returns_Error_Response()
         {
             // Arrange
-            var futureDate = DateTime.Now.AddDays(1);
+            var futureDate = DateTime.UtcNow.AddDays(10);
 
             // Act
             var response = await _testHarness.PolygonClient.GetDailyMarketSummary(futureDate);


### PR DESCRIPTION
Hi, there was a test failure in the run https://github.com/rwitzlib/polygon-dotnet-client/actions/runs/15099239450/job/42438007467 - it's most probably becasue Polygon uses time in different timezone that the machine building the code, and test expected failure while the server returned OK. This should not happen anymore after this fix