### PR TITLE
Run Build/Test on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Nuget Package Publish
+
+run-name: ${{ github.actor }} is running Nuget Publish
+
+on:
+  pull_request:
+    branches:
+      - master
+
+env:
+  POLYGON_TOKEN: ${{ secrets.POLYGON_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
+      - run: |
+          dotnet clean
+          dotnet restore
+          dotnet build
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
+      - run: |
+          dotnet test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Nuget Package Publish
+name: Build & Test
 
 run-name: ${{ github.actor }} is running Nuget Publish
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build & Test
 
-run-name: ${{ github.actor }} is running Nuget Publish
+run-name: ${{ github.actor }} is running Build & Test
 
 on:
   pull_request:

--- a/.github/workflows/nuget-package-publish.yml
+++ b/.github/workflows/nuget-package-publish.yml
@@ -2,7 +2,10 @@ name: Nuget Package Publish
 
 run-name: ${{ github.actor }} is running Nuget Publish
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 env:
   POLYGON_TOKEN: ${{ secrets.POLYGON_TOKEN }}

--- a/Polygon.Client.UnitTests/GetDailyMarketSummaryUnitTests.cs
+++ b/Polygon.Client.UnitTests/GetDailyMarketSummaryUnitTests.cs
@@ -58,7 +58,7 @@ namespace Polygon.Client.UnitTests
 
             // Assert
             response.Should().NotBeNull();
-            response.Status.Should().NotBe(HttpStatusCode.OK.ToString());
+            response.Status.Should().Be(HttpStatusCode.OK.ToString());
             response.Results.Should().BeEmpty();
             response.QueryCount.Should().Be(0);
             response.ResultsCount.Should().Be(0);


### PR DESCRIPTION
Adding in pipelines so build & tests run on push when you have a PR opened.  Also took a look at the failing unit test.  Looks like the behavior is that it still returns an OK status code even with an invalid date.  Also tested right from the docs to ensure this is expected behavior 
![image](https://github.com/user-attachments/assets/b8c56376-3bc2-4af7-a93f-a16ed2444c2c)
@PFalkowski 